### PR TITLE
Pass instance data to SNS topic

### DIFF
--- a/ebs_snapper/lambdas.py
+++ b/ebs_snapper/lambdas.py
@@ -85,11 +85,15 @@ def lambda_snapshot(event, context):
             LOG.warn('lambda_snapshot missing specific keys: %s', str(event))
             continue
 
+        if 'instance_data' in message_json:
+            opt_instance_data = message_json['instance_data']
+
         # call the snapshot perform method
         snapshot.perform_snapshot(
             message_json['region'],
             message_json['instance_id'],
             message_json['settings'],
+            instance_data=opt_instance_data,
             context=context)
 
         LOG.info('Function lambda_snapshot completed')

--- a/ebs_snapper/shell.py
+++ b/ebs_snapper/shell.py
@@ -149,11 +149,15 @@ def shell_snapshot(*args):
     """Check for snapshots, executing if needed, like lambda version."""
     message_json = json.loads(args[0].message)
 
+    if 'instance_data' in message_json:
+        d = message_json['instance_data']
+
     # call the snapshot perform method
     snapshot.perform_snapshot(
         message_json['region'],
         message_json['instance_id'],
-        message_json['settings'])
+        message_json['settings'],
+        instance_data=d)
 
     LOG.info('Function shell_snapshot completed')
 


### PR DESCRIPTION
- Pass the instance data from `describe_instances` to the SNS topic

- If we get instance data on the SNS topic, use it instead of looking it all up again

- Sanitize instance data; it may contain un-JSON-serializable values like datetime(s)

RE: #5