### PR TITLE
Reduce noise from the tool

### DIFF
--- a/ebs_snapper/clean.py
+++ b/ebs_snapper/clean.py
@@ -98,6 +98,9 @@ def clean_snapshot(region,
     if deleted_count <= 0:
         LOG.warn('No snapshots were cleaned up for the entire region %s', region)
 
+    if elapsed_time > datetime.timedelta(minutes=4):
+        LOG.warn('Timed out while cleaning snapshots for region %s: %s', region, str(elapsed_time))
+
 
 def clean_snapshots_tagged(start_time, delete_on,
                            owner_ids, region, configurations, default_min_snaps=5):
@@ -125,6 +128,8 @@ def clean_snapshots_tagged(start_time, delete_on,
         # be sure we haven't overrun the time to run
         elapsed_time = datetime.datetime.now(dateutil.tz.tzutc()) - start_time
         if elapsed_time >= datetime.timedelta(minutes=4):
+            LOG.warn('Timed out while cleaning snapshots: %s', str(elapsed_time))
+            LOG.warn('clean_snapshots_tagged region %s and DeleteOn: %s', region, delete_on)
             return deleted_count
         sleep(1)  # help with API limit
 

--- a/ebs_snapper/utils.py
+++ b/ebs_snapper/utils.py
@@ -43,7 +43,7 @@ AWS_TAGS = [
     "Billing1", "Billing2", "Billing3", "Billing4", "Billing5"
 ]
 SNAP_DESC_TEMPLATE = "Created from {0} by EbsSnapper({3}) for {1} from {2}"
-ALLOWED_SNAPSHOT_DELETE_FAILURES = ['InvalidSnapshot.InUse']
+ALLOWED_SNAPSHOT_DELETE_FAILURES = ['InvalidSnapshot.InUse', 'InvalidSnapshot.NotFound']
 
 
 def get_owner_id(region=None, context=None):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -279,7 +279,6 @@ def test_calculate_relevant_tags():
         'BusinessUnit': 'Dept2',
         'Cluster': 'Bank',
         'DeleteOn': delete_on,
-        "Foo": "Baz"  # hard coded tag
         # moto returns tags in very random order, for testing purposes,
         # so I can't really test anything else with the foo-* tags here
     }


### PR DESCRIPTION
-  	Don't error if snapshot missing
-  	Log when we go over the 4 minute timer 