### PR TITLE
More optimization work

### DIFF
--- a/ebs_snapper/__init__.py
+++ b/ebs_snapper/__init__.py
@@ -21,8 +21,22 @@
 #
 """Module for doing EBS snapshots and cleaning up snapshots."""
 
+import logging
+
 __title__ = 'ebs_snapper'
 __version__ = '0.3.6'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright Rackspace US, Inc. 2015-2016'
 __url__ = 'https://github.com/rackerlabs/ebs-snapper-lambda-v2'
+
+LOG = logging.getLogger(__name__)
+
+
+def timeout_check(context, place):
+    """Return True if we have less than 1 minute remaining"""
+
+    if context.get_remaining_time_in_millis() < 60000:
+        LOG.warn('Lambda/Less than 1m: %s', place)
+        return True
+
+    return False

--- a/ebs_snapper/clean.py
+++ b/ebs_snapper/clean.py
@@ -41,6 +41,7 @@ def perform_fanout_all_regions(context=None):
 
     regions = utils.get_regions(must_contain_instances=True)
     for region in regions:
+        sleep(5) # API limit relief
         send_fanout_message(region=region, topic_arn=sns_topic)
 
     LOG.info('Function clean_perform_fanout_all_regions completed')

--- a/ebs_snapper/clean.py
+++ b/ebs_snapper/clean.py
@@ -41,7 +41,7 @@ def perform_fanout_all_regions(context=None):
 
     regions = utils.get_regions(must_contain_instances=True)
     for region in regions:
-        sleep(5) # API limit relief
+        sleep(5)  # API limit relief
         send_fanout_message(region=region, topic_arn=sns_topic)
 
     LOG.info('Function clean_perform_fanout_all_regions completed')

--- a/ebs_snapper/deploy.py
+++ b/ebs_snapper/deploy.py
@@ -49,7 +49,7 @@ IGNORED_UPLOADER_FILES = ["circle.yml", ".git", "/*.pyc", "\\.cache",
                           "\\.json$", "\\.sh$", "\\.zip$"]
 
 
-def deploy(aws_account_id=None, no_build=None, no_upload=None, no_stack=None, context=None):
+def deploy(context, aws_account_id=None, no_build=None, no_upload=None, no_stack=None):
     """Main function that does the deploy to an aws account"""
     # lambda-uploader configuration step
 
@@ -62,7 +62,7 @@ def deploy(aws_account_id=None, no_build=None, no_upload=None, no_stack=None, co
     needs_owner_id = (not no_upload) or (not no_stack)
     if needs_owner_id:
         if aws_account_id is None:
-            found_owners = utils.get_owner_id(context=context)
+            found_owners = utils.get_owner_id(context)
         else:
             found_owners = [aws_account_id]
 

--- a/ebs_snapper/dynamo.py
+++ b/ebs_snapper/dynamo.py
@@ -28,11 +28,11 @@ from boto3.dynamodb.conditions import Key
 from ebs_snapper import utils
 
 
-def list_ids(installed_region, aws_account_id=None, context=None):
+def list_ids(context, installed_region, aws_account_id=None):
     """Retrieve configuration from DynamoDB and return array of dictionary objects"""
     found_configurations = {}
     if aws_account_id is None:
-        aws_account_id = utils.get_owner_id(context=context)[0]
+        aws_account_id = utils.get_owner_id(context)[0]
 
     dynamodb = boto3.resource('dynamodb', region_name=installed_region)
     table = dynamodb.Table('ebs_snapshot_configuration')
@@ -48,11 +48,11 @@ def list_ids(installed_region, aws_account_id=None, context=None):
     return found_configurations.values()
 
 
-def list_configurations(installed_region, aws_account_id=None, context=None):
+def list_configurations(context, installed_region, aws_account_id=None):
     """Retrieve configuration from DynamoDB and return array of dictionary objects"""
     found_configurations = {}
     if aws_account_id is None:
-        aws_account_id = utils.get_owner_id(context=context)[0]
+        aws_account_id = utils.get_owner_id(context)[0]
 
     dynamodb = boto3.resource('dynamodb', region_name=installed_region)
     table = dynamodb.Table('ebs_snapshot_configuration')
@@ -69,10 +69,10 @@ def list_configurations(installed_region, aws_account_id=None, context=None):
     return found_configurations.values()
 
 
-def get_configuration(installed_region, object_id, aws_account_id=None, context=None):
+def get_configuration(context, installed_region, object_id, aws_account_id=None):
     """Retrieve configuration from DynamoDB and return single object"""
     if aws_account_id is None:
-        aws_account_id = utils.get_owner_id(context=context)[0]
+        aws_account_id = utils.get_owner_id(context)[0]
 
     dynamodb = boto3.resource('dynamodb', region_name=installed_region)
     table = dynamodb.Table('ebs_snapshot_configuration')

--- a/ebs_snapper/lambdas.py
+++ b/ebs_snapper/lambdas.py
@@ -39,7 +39,7 @@ def lambda_fanout_snapshot(event, context):
     LOG.setLevel(logging.INFO)
 
     # for every region and every instance, send to this function
-    snapshot.perform_fanout_all_regions(context=context)
+    snapshot.perform_fanout_all_regions(context)
 
     LOG.info('Function lambda_fanout_snapshot completed')
 
@@ -52,7 +52,7 @@ def lambda_fanout_clean(event, context):
     LOG.setLevel(logging.INFO)
 
     # for every region, send to this function
-    clean.perform_fanout_all_regions(context=context)
+    clean.perform_fanout_all_regions(context)
 
     LOG.info('Function lambda_fanout_clean completed')
 
@@ -93,11 +93,11 @@ def lambda_snapshot(event, context):
 
         # call the snapshot perform method
         snapshot.perform_snapshot(
+            context,
             message_json['region'],
             message_json['instance_id'],
             message_json['settings'],
-            instance_data=opt_instance_data,
-            context=context)
+            instance_data=opt_instance_data)
 
         LOG.info('Function lambda_snapshot completed')
 
@@ -132,6 +132,6 @@ def lambda_clean(event, context):
             continue
 
         # call the snapshot cleanup method
-        clean.clean_snapshot(message_json['region'], context=context)
+        clean.clean_snapshot(context, message_json['region'])
 
     LOG.info('Function lambda_clean completed')

--- a/ebs_snapper/snapshot.py
+++ b/ebs_snapper/snapshot.py
@@ -22,6 +22,7 @@
 """Module for doing EBS snapshots."""
 
 from __future__ import print_function
+from time import sleep
 import json
 import logging
 from datetime import timedelta
@@ -40,6 +41,7 @@ def perform_fanout_all_regions(context=None):
     # get regions with instances running or stopped
     regions = utils.get_regions(must_contain_instances=True)
     for region in regions:
+        sleep(5) # API rate limiting help
         perform_fanout_by_region(region=region, context=context)
 
 
@@ -56,7 +58,7 @@ def perform_fanout_by_region(region, installed_region='us-east-1', context=None)
 
     # for every configuration
     for config in configurations:
-
+        sleep(5) # API rate limiting help
         # if it's missing the match section, ignore it
         if not utils.validate_snapshot_settings(config):
             continue
@@ -92,6 +94,7 @@ def send_message_instances(region, sns_topic, configuration_snapshot, filters):
 
     for reservation in instances.get('Reservations', []):
         for instance in reservation.get('Instances', []):
+            sleep(5) # API rate limiting help
             send_fanout_message(
                 instance_id=instance['InstanceId'],
                 region=region,

--- a/ebs_snapper/snapshot.py
+++ b/ebs_snapper/snapshot.py
@@ -147,7 +147,12 @@ def perform_snapshot(region, instance, snapshot_settings, instance_data=None, co
         # perform actual snapshot and create tag: retention + now() as a Y-M-D
         delete_on_dt = now + retention
         delete_on = delete_on_dt.strftime('%Y-%m-%d')
-        expected_tags = utils.calculate_relevant_tags(instance, volume_id, region)
+
+        volume_data = utils.get_volume(volume_id, region=region)
+        expected_tags = utils.calculate_relevant_tags(
+            instance_data.get('Tags', None),
+            volume_data.get('Tags', None))
+
         utils.snapshot_and_tag(
             instance,
             ami_id,

--- a/ebs_snapper/snapshot.py
+++ b/ebs_snapper/snapshot.py
@@ -30,28 +30,28 @@ import datetime
 import dateutil
 
 import boto3
-from ebs_snapper import utils, dynamo
+from ebs_snapper import utils, dynamo, timeout_check
 
 
 LOG = logging.getLogger(__name__)
 
 
-def perform_fanout_all_regions(context=None):
+def perform_fanout_all_regions(context):
     """For every region, run the supplied function"""
     # get regions with instances running or stopped
     regions = utils.get_regions(must_contain_instances=True)
     for region in regions:
         sleep(5)  # API rate limiting help
-        perform_fanout_by_region(region=region, context=context)
+        perform_fanout_by_region(context, region)
 
 
-def perform_fanout_by_region(region, installed_region='us-east-1', context=None):
+def perform_fanout_by_region(context, region, installed_region='us-east-1'):
     """For a specific region, run this function for every matching instance"""
 
     sns_topic = utils.get_topic_arn('CreateSnapshotTopic', installed_region)
 
     # get all configurations, so we can filter instances
-    configurations = dynamo.list_configurations(installed_region)
+    configurations = dynamo.list_configurations(context, installed_region)
     if len(configurations) <= 0:
         LOG.warn('No EBS snapshot configurations were found for region %s', region)
         LOG.warn('No new snapshots will be created for region %s', region)
@@ -119,7 +119,7 @@ def send_fanout_message(instance_id, region, topic_arn, snapshot_settings, insta
     utils.sns_publish(TopicArn=topic_arn, Message=message)
 
 
-def perform_snapshot(region, instance, snapshot_settings, instance_data=None, context=None):
+def perform_snapshot(context, region, instance, snapshot_settings, instance_data=None):
     """Check the region and instance, and see if we should take any snapshots"""
     LOG.info('Reviewing snapshots in region %s on instance %s', region, instance)
 
@@ -136,6 +136,10 @@ def perform_snapshot(region, instance, snapshot_settings, instance_data=None, co
         LOG.debug('Considering device %s', dev)
         volume_id = dev['Ebs']['VolumeId']
 
+        # before we go pull tons of snapshots
+        if timeout_check(context, 'perform_snapshot'):
+            break
+
         # find snapshots
         recent = utils.most_recent_snapshot(volume_id, region)
         now = datetime.datetime.now(dateutil.tz.tzutc())
@@ -150,6 +154,10 @@ def perform_snapshot(region, instance, snapshot_settings, instance_data=None, co
         # perform actual snapshot and create tag: retention + now() as a Y-M-D
         delete_on_dt = now + retention
         delete_on = delete_on_dt.strftime('%Y-%m-%d')
+
+        # before we go make a bunch more API calls
+        if timeout_check(context, 'perform_snapshot'):
+            break
 
         volume_data = utils.get_volume(volume_id, region=region)
         expected_tags = utils.calculate_relevant_tags(

--- a/ebs_snapper/snapshot.py
+++ b/ebs_snapper/snapshot.py
@@ -41,7 +41,7 @@ def perform_fanout_all_regions(context=None):
     # get regions with instances running or stopped
     regions = utils.get_regions(must_contain_instances=True)
     for region in regions:
-        sleep(5) # API rate limiting help
+        sleep(5)  # API rate limiting help
         perform_fanout_by_region(region=region, context=context)
 
 
@@ -58,7 +58,7 @@ def perform_fanout_by_region(region, installed_region='us-east-1', context=None)
 
     # for every configuration
     for config in configurations:
-        sleep(5) # API rate limiting help
+        sleep(5)  # API rate limiting help
         # if it's missing the match section, ignore it
         if not utils.validate_snapshot_settings(config):
             continue
@@ -94,7 +94,7 @@ def send_message_instances(region, sns_topic, configuration_snapshot, filters):
 
     for reservation in instances.get('Reservations', []):
         for instance in reservation.get('Instances', []):
-            sleep(5) # API rate limiting help
+            sleep(5)  # API rate limiting help
             send_fanout_message(
                 instance_id=instance['InstanceId'],
                 region=region,

--- a/ebs_snapper/utils.py
+++ b/ebs_snapper/utils.py
@@ -348,7 +348,7 @@ def get_volumes(instance_ids, region):
 
     volumes = []
     filters_for_instances = [
-        {'Name': 'attachment.instance-id', 'Values':instance_ids}
+        {'Name': 'attachment.instance-id', 'Values': instance_ids}
     ]
 
     ec2 = boto3.client('ec2', region_name=region)

--- a/ebs_snapper/utils.py
+++ b/ebs_snapper/utils.py
@@ -397,7 +397,7 @@ def get_snapshot_settings_by_instance(instance_id, configurations, region):
     return None
 
 
-def calculate_relevant_tags(instance_id, volume_id, region, max_results=10):
+def calculate_relevant_tags(instance_tags, volume_tags, max_results=10):
     """Copy AWS tags from instance to volume to snapshot, per product guide"""
 
     # ordered dict of tags, because we care about order
@@ -408,26 +408,18 @@ def calculate_relevant_tags(instance_id, volume_id, region, max_results=10):
         calculated_tags[billing_tag] = None
 
     # first figure out any instance tags
-    if instance_id is not None:
-        instance_data = get_instance(instance_id, region)
-        if instance_data is not None and 'Tags' in instance_data:
-            instance_tags = instance_data['Tags']
-
-            # add relevant ones to the list
-            for tag_ds in instance_tags:
-                tag_name, tag_value = tag_ds['Key'], tag_ds['Value']
-                calculated_tags[tag_name] = tag_value
+    if instance_tags is not None:
+        # add relevant ones to the list
+        for tag_ds in instance_tags:
+            tag_name, tag_value = tag_ds['Key'], tag_ds['Value']
+            calculated_tags[tag_name] = tag_value
 
     # overwrite tag values from instances with volume tags/values
-    if volume_id is not None:
-        volume_data = get_volume(volume_id, region)
-        if volume_data is not None and 'Tags' in volume_data:
-            volume_tags = volume_data['Tags']
-
-            # add relevant ones to the list
-            for tag_ds in volume_tags:
-                tag_name, tag_value = tag_ds['Key'], tag_ds['Value']
-                calculated_tags[tag_name] = tag_value
+    if volume_tags is not None:
+        # add relevant ones to the list
+        for tag_ds in volume_tags:
+            tag_name, tag_value = tag_ds['Key'], tag_ds['Value']
+            calculated_tags[tag_name] = tag_value
 
     returned_tags = []
     for n, v in calculated_tags.iteritems():

--- a/ebs_snapper/utils.py
+++ b/ebs_snapper/utils.py
@@ -46,7 +46,7 @@ SNAP_DESC_TEMPLATE = "Created from {0} by EbsSnapper({3}) for {1} from {2}"
 ALLOWED_SNAPSHOT_DELETE_FAILURES = ['InvalidSnapshot.InUse', 'InvalidSnapshot.NotFound']
 
 
-def get_owner_id(region=None, context=None):
+def get_owner_id(context, region=None):
     """Get overall owner account id using a bunch of tricks"""
     LOG.debug('get_owner_id')
 
@@ -521,3 +521,22 @@ def find_deleteon_tags(region_name, cutoff_date, max_tags=10):
 
     # return max values at most, sorted by lexical (oldest!)
     return sorted(results_found[:max_tags])
+
+
+class MockContext(object):
+    """Context object when we're not running in lambda"""
+
+    def __init__(self):
+        # 2.5 minutes in millis
+        self.remaining_time = 150000
+
+        # called to figure out owner
+        self.invoked_function_arn = None
+
+    def get_remaining_time_in_millis(self):
+        """Always return 2.5 minutes, unless mocked otherwise"""
+        return self.remaining_time
+
+    def set_remaining_time_in_millis(self, millis):
+        """Used to mock other values"""
+        self.remaining_time = millis

--- a/ebs_snapper/utils.py
+++ b/ebs_snapper/utils.py
@@ -321,6 +321,9 @@ def snapshot_and_tag(instance_id, ami_id, volume_id, delete_on, region, addition
         Tags=full_tags
     )
 
+    LOG.warn('Finished snapshot in %s of volume %s, valid until %s',
+             region, volume_id, delete_on)
+
 
 def delete_snapshot(snapshot_id, region):
     """Simple wrapper around deletes so we can mock them"""

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -141,7 +141,7 @@ def test_clean_tagged_snapshots(mocker):
     dynamo.store_configuration(region, 'foo', '111122223333', config_data)
 
     # figure out the EBS volume that came with our instance
-    volume_id = utils.get_volumes(instance_id, region)[0]
+    volume_id = utils.get_volumes([instance_id], region)[0]['VolumeId']
 
     # make a snapshot that should be deleted today too
     now = datetime.datetime.now(dateutil.tz.tzutc())
@@ -194,7 +194,7 @@ def test_clean_snapshots_tagged_timeout(mocker):
     dynamo.store_configuration(region, 'foo', '111122223333', config_data)
 
     # figure out the EBS volume that came with our instance
-    volume_id = utils.get_volumes(instance_id, region)[0]
+    volume_id = utils.get_volumes([instance_id], region)[0]['VolumeId']
 
     # make a snapshot that should be deleted today too
     now = datetime.datetime.now(dateutil.tz.tzutc())

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -44,13 +44,15 @@ def test_perform_fanout_all_regions_clean(mocker):
         mocks.create_instances(region=r)
     expected_sns_topic = utils.get_topic_arn('CleanSnapshotTopic', 'us-east-1')
 
+    ctx = utils.MockContext()
     mocker.patch('ebs_snapper.clean.send_fanout_message')
 
     # fan out, and be sure we touched every region
-    clean.perform_fanout_all_regions()
+    clean.perform_fanout_all_regions(ctx)
 
     for r in expected_regions:
         clean.send_fanout_message.assert_any_call(  # pylint: disable=E1103
+            ctx,
             region=r,
             topic_arn=expected_sns_topic)
 
@@ -64,9 +66,10 @@ def test_send_fanout_message_clean(mocker):
 
     mocks.create_sns_topic('testing-topic')
     expected_sns_topic = utils.get_topic_arn('testing-topic', 'us-east-1')
+    ctx = utils.MockContext()
 
     mocker.patch('ebs_snapper.utils.sns_publish')
-    clean.send_fanout_message(region='us-west-2', topic_arn=expected_sns_topic)
+    clean.send_fanout_message(ctx, region='us-west-2', topic_arn=expected_sns_topic)
     utils.sns_publish.assert_any_call(  # pylint: disable=E1103
         TopicArn=expected_sns_topic,
         Message=json.dumps({'region': 'us-west-2'}))
@@ -80,10 +83,11 @@ def test_clean_snapshot(mocker):
     """Test for method of the same name."""
     # def clean_snapshot(region):
     region = 'us-east-1'
+    ctx = utils.MockContext()
 
     # need an instance to get figure out an owner
     instance_id = mocks.create_instances(region, count=1)[0]
-    owner_ids = utils.get_owner_id()
+    owner_ids = utils.get_owner_id(ctx)
 
     # setup the min # snaps for the instance
     config_data = {
@@ -98,17 +102,17 @@ def test_clean_snapshot(mocker):
     dynamo.store_configuration(region, 'foo', '111122223333', config_data)
 
     # make a snapshot, so we can find it and delete it
-    snapshot.perform_snapshot(region, instance_id, config_data)
+    snapshot.perform_snapshot(ctx, region, instance_id, config_data)
 
     # mock the over-arching method that just loops over the last 10 days
     now = datetime.datetime.now(dateutil.tz.tzutc())
     mocker.patch('ebs_snapper.clean.clean_snapshots_tagged')
-    clean.clean_snapshot(region, started_run=now)
+    clean.clean_snapshot(ctx, region, started_run=now)
 
     # be sure we call delete for the negative retention in -7 days
     delete_on = datetime.date.today() + timedelta(days=-7)
     clean.clean_snapshots_tagged.assert_any_call(  # pylint: disable=E1103
-        now,
+        ctx,
         delete_on.strftime('%Y-%m-%d'),
         owner_ids,
         region,
@@ -127,7 +131,8 @@ def test_clean_tagged_snapshots(mocker):
 
     # create an instance and record the id
     instance_id = mocks.create_instances(region, count=1)[0]
-    owner_ids = utils.get_owner_id()
+    ctx = utils.MockContext()
+    owner_ids = utils.get_owner_id(ctx)
 
     # setup the min # snaps for the instance
     config_data = {
@@ -149,10 +154,8 @@ def test_clean_tagged_snapshots(mocker):
     utils.snapshot_and_tag(instance_id, 'ami-123abc', volume_id, delete_on, region)
     snapshot_id = utils.most_recent_snapshot(volume_id, region)['SnapshotId']
 
-    now_time = datetime.datetime.now(dateutil.tz.tzutc())
-
     mocker.patch('ebs_snapper.utils.delete_snapshot')
-    clean.clean_snapshots_tagged(now_time,
+    clean.clean_snapshots_tagged(ctx,
                                  now.strftime('%Y-%m-%d'),
                                  owner_ids, region, [config_data])
 
@@ -163,7 +166,7 @@ def test_clean_tagged_snapshots(mocker):
     utils.delete_snapshot.reset_mock()  # pylint: disable=E1103
     config_data['snapshot']['minimum'] = 5
     dynamo.store_configuration(region, 'foo', '111122223333', config_data)
-    clean.clean_snapshots_tagged(now_time, now.strftime('%Y-%m-%d'),
+    clean.clean_snapshots_tagged(ctx, now.strftime('%Y-%m-%d'),
                                  owner_ids, region, [config_data])
     utils.delete_snapshot.assert_not_called()  # pylint: disable=E1103
 
@@ -177,10 +180,12 @@ def test_clean_snapshots_tagged_timeout(mocker):
     # default settings
     region = 'us-east-1'
     mocks.create_dynamodb(region)
+    ctx = utils.MockContext()
+    ctx.set_remaining_time_in_millis(5)  # 5 millis remaining
 
     # create an instance and record the id
     instance_id = mocks.create_instances(region, count=1)[0]
-    owner_ids = utils.get_owner_id()
+    owner_ids = utils.get_owner_id(ctx)
 
     # setup the min # snaps for the instance
     config_data = {
@@ -201,10 +206,8 @@ def test_clean_snapshots_tagged_timeout(mocker):
     delete_on = now.strftime('%Y-%m-%d')
     utils.snapshot_and_tag(instance_id, 'ami-123abc', volume_id, delete_on, region)
 
-    now_time = datetime.datetime.now(dateutil.tz.tzutc()) + timedelta(minutes=-5)
-
     mocker.patch('ebs_snapper.utils.delete_snapshot')
-    clean.clean_snapshots_tagged(now_time,
+    clean.clean_snapshots_tagged(ctx,
                                  now.strftime('%Y-%m-%d'),
                                  owner_ids, region, [config_data])
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -195,7 +195,7 @@ def test_snapshot_helper_methods():
     instance_id = mocks.create_instances(region, count=1)[0]
 
     # figure out the EBS volume that came with our instance
-    volume_id = utils.get_volumes(instance_id, region)[0]
+    volume_id = utils.get_volumes([instance_id], region)[0]['VolumeId']
 
     # make some snapshots that should be deleted today too
     now = datetime.now(dateutil.tz.tzutc())
@@ -251,7 +251,7 @@ def test_calculate_relevant_tags():
     )
 
     # figure out the EBS volume that came with our instance
-    volume_id = utils.get_volumes(instance_id, region)[0]
+    volume_id = utils.get_volumes([instance_id], region)[0]['VolumeId']
     client.create_tags(
         Resources=[volume_id],
         Tags=volume_tags
@@ -315,7 +315,7 @@ def test_find_deleteon_tags():
         delete_on = cutoff.strftime('%Y-%m-%d')
 
         # create the snapshot
-        volume_id = utils.get_volumes(instance_id, region)[0]
+        volume_id = utils.get_volumes([instance_id], region)[0]['VolumeId']
         vol_data = utils.get_volume(volume_id, region=region)
         inst_data = utils.get_instance(instance_id, region=region)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -261,8 +261,13 @@ def test_calculate_relevant_tags():
     now = datetime.now(dateutil.tz.tzutc())
     delete_on = now.strftime('%Y-%m-%d')
 
+    instance_data = utils.get_instance(instance_id, region=region)
+    volume_data = utils.get_volume(volume_id, region=region)
+    expected_tags = utils.calculate_relevant_tags(
+        instance_data.get('Tags', None),
+        volume_data.get('Tags', None))
+
     # create the snapshot
-    expected_tags = utils.calculate_relevant_tags(instance_id, volume_id, region)
     utils.snapshot_and_tag(instance_id,
                            'ami-123abc',
                            volume_id,
@@ -311,7 +316,13 @@ def test_find_deleteon_tags():
 
         # create the snapshot
         volume_id = utils.get_volumes(instance_id, region)[0]
-        expected_tags = utils.calculate_relevant_tags(instance_id, volume_id, region)
+        vol_data = utils.get_volume(volume_id, region=region)
+        inst_data = utils.get_instance(instance_id, region=region)
+
+        expected_tags = utils.calculate_relevant_tags(
+            inst_data.get('Tags'),
+            vol_data.get('Tags')
+        )
         utils.snapshot_and_tag(instance_id,
                                'ami-123abc',
                                volume_id,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,7 +38,7 @@ def test_get_owner_id():
     client.run_instances(ImageId='ami-123abc', MinCount=1, MaxCount=5)
 
     # show that get_owner_id can get the dummy owner id
-    assert ['111122223333'] == utils.get_owner_id()
+    assert ['111122223333'] == utils.get_owner_id(utils.MockContext())
 
 
 @mock_ec2


### PR DESCRIPTION
- Reduce the API footprint of utils#calculate_relevant_tags. It now accepts existing tags vs. looking them up itself.
- Pass existing tags for the instances to the method above. We still have to lookup volumes (to get their tags), but this should help.
- Add some sleeps for fanning out (fan out much, much slower)
- Log when a snapshot is completed, in addition to when we start.
- Make `get_volumes(instance_ids, region)` more efficient
- Improve duration check, using Lambda's context object instead of timing it ourselves. Also check the duration during snapshots, not just cleaning up.