### PR TITLE
Test parse configs before saving

### DIFF
--- a/ebs_snapper/dynamo.py
+++ b/ebs_snapper/dynamo.py
@@ -93,6 +93,9 @@ def store_configuration(installed_region, object_id, aws_account_id, configurati
     dynamodb = boto3.resource('dynamodb', region_name=installed_region)
     table = dynamodb.Table('ebs_snapshot_configuration')
 
+    # be sure they parse correctly before we go saving them
+    utils.parse_snapshot_settings(configuration)
+
     response = table.put_item(
         Item={
             'aws_account_id': aws_account_id,

--- a/ebs_snapper/utils.py
+++ b/ebs_snapper/utils.py
@@ -197,8 +197,13 @@ def parse_snapshot_settings(snapshot_settings):
         if k not in snapshot_settings['snapshot']:
             raise Exception('missing required snapshot setting {}'.format(k))
 
-    retention_seconds = timeparse(snapshot_settings['snapshot']['retention'])
-    retention = timedelta(seconds=retention_seconds)
+    ret_s = snapshot_settings['snapshot']['retention']
+    retention = timeparse('7 days')
+    try:
+        retention_seconds = timeparse(ret_s)
+        retention = timedelta(seconds=retention_seconds)
+    except:
+        raise Exception('Could not parse snapshot retention value', ret_s)
 
     f_expr = snapshot_settings['snapshot']['frequency']
     if is_timedelta_expression(f_expr):


### PR DESCRIPTION
Be sure we test the configurations before saving, in case we stumble upon any formatting issues or parsing errors due to ambiguous periods (e.g. '1 month' vs. '30 days') for retention.

Fixes #13.