### PR TITLE
Only use ignore_retention if necessary

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -31,7 +31,7 @@ Note: All instances will be filtered by whether they are running or stopped, usi
     - An array of instance or volume ids to ignore when doing snapshots or cleanups
 
   - ignore_retention flag
-    - a JSON boolean value, if enabled, causes EBS Snapper to ignore any snapshot retention settings (minimum number of snapshots present), and delete all snapshots with an appropriate `DeleteOn` tag
+    - a JSON boolean value, if enabled, causes EBS Snapper to ignore snapshot retention settings when it can't calculate the minimum number of snapshots present, and delete a snapshots with an appropriate `DeleteOn` tag regardless
 
 [1] http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_instances
 


### PR DESCRIPTION
Make a slight behavior adjustment to the ignore_retention flag. Only ignore retention, when cleaning up snapshots, if we can't find an instance and volume to map a snapshot back to. We would normally use the mapping to count how many other snapshots exist. If we simply fail to do that, don't assume the count is zero either -- use the new flag.

Fixes #14.