### PR TITLE
Be sure we only touch retention when touching functions

### DIFF
--- a/ebs_snapper/deploy.py
+++ b/ebs_snapper/deploy.py
@@ -86,8 +86,7 @@ def deploy(context, aws_account_id=None, no_build=None, no_upload=None, no_stack
     # freshen up lambda jobs themselves
     if not no_upload:
         update_function_and_version(ebs_bucket_name, lambda_zip_filename)
-
-    ensure_cloudwatch_logs_retention(aws_account)
+        ensure_cloudwatch_logs_retention(aws_account)
 
 
 def create_or_update_s3_bucket(aws_account, lambda_zip_filename):


### PR DESCRIPTION
Be sure we only try to update the retention values if we're going to deploy Lambda functions. Otherwise the aws_account_id variable isn't defined.

Fixes #26.