### PR TITLE
Better error logging for bad configurations

### DIFF
--- a/ebs_snapper/__init__.py
+++ b/ebs_snapper/__init__.py
@@ -22,6 +22,7 @@
 """Module for doing EBS snapshots and cleaning up snapshots."""
 
 import logging
+import sys
 
 __title__ = 'ebs_snapper'
 __version__ = '0.6.1'
@@ -43,3 +44,11 @@ def timeout_check(context, place):
         return True
 
     return False
+
+
+class EbsSnapperError(Exception):
+    """Custom exception for nicer error messages"""
+    def __init__(self, msg, other):
+        self.traceback = sys.exc_info()
+        new_msg = '{}: {}'.format(msg, other.message)
+        super(EbsSnapperError, self).__init__(new_msg)


### PR DESCRIPTION
- Introduce a custom exception class so we can provide better error messages
- Catch JSON #loads exceptions, wrap in the new error class
- Add a test to confirm that we're now throwing our custom exception instead of JSON parsing ones

New exceptions look like:
```
E EbsSnapperError: error loading configuration: Expecting property name enclosed in double quotes: line 1 column 2 (char 1)
```

Fixes #28.