### PR TITLE
Configuration bugfix and documentation updates

### DIFF
--- a/ebs_snapper/shell.py
+++ b/ebs_snapper/shell.py
@@ -32,7 +32,7 @@ import ebs_snapper
 from ebs_snapper import snapshot, clean, dynamo, utils, deploy
 
 LOG = logging.getLogger()
-CTX = utils.MockContext()
+CTX = utils.ShellContext()
 
 
 def main(arv=None):
@@ -185,7 +185,7 @@ def shell_configure(*args):
     installed_region = args[0].conf_toolregion
 
     if action == 'list':
-        LOG.info('Listing all object keys')
+        LOG.info('Listing all object keys for %s', aws_account_id)
         list_results = dynamo.list_ids(
             CTX,
             installed_region,

--- a/ebs_snapper/utils.py
+++ b/ebs_snapper/utils.py
@@ -670,8 +670,8 @@ def chunk_volume_work(region, volume_list):
     }
 
 
-class MockContext(object):
-    """Context object when we're not running in lambda"""
+class NonLambdaContext(object):
+    """Context for when we're not running in Lambda"""
     # Useful information about the LambdaContext object
     # https://gist.github.com/gene1wood/c0d37dfcb598fc133a8c
 
@@ -702,3 +702,11 @@ class MockContext(object):
     def timedelta_milliseconds(td):
         """return milliseconds from a timedelta"""
         return td.days*86400000 + td.seconds*1000 + td.microseconds/1000
+
+
+class ShellContext(NonLambdaContext):
+    """Context for when we're running in the shell"""
+
+
+class MockContext(NonLambdaContext):
+    """Context object when we're running tests"""


### PR DESCRIPTION
- The shell and our tests shouldn't use the same fake/mock context object (#34)
- Clean up `clean` CLI command example (#30)
- Add note about virtualenv (#31)