### PR TITLE
Fix permissions for scheduled rule

### DIFF
--- a/cloudformation.json
+++ b/cloudformation.json
@@ -474,7 +474,7 @@
       "Properties": {
         "FunctionName" : { "Fn::GetAtt" : ["FanoutReplicationSnapshotFunction", "Arn"] },
         "Action": "lambda:InvokeFunction",
-        "Principal": "sns.amazonaws.com",
+        "Principal": "events.amazonaws.com",
         "SourceArn" : { "Fn::GetAtt": ["ScheduledRuleReplicationFunction", "Arn"] }
       }
     },


### PR DESCRIPTION
Scheduled rules fire from events.amazonaws.com, not sns.amazonaws.com.