### PR TITLE
Keep CFN Parameters, add OKActions, improve docs.

### DIFF
--- a/cloudformation.json
+++ b/cloudformation.json
@@ -109,6 +109,14 @@
                 }, "rackspace-support-standard"]]
           }
         ],
+        "OKActions" : [{
+            "Fn::Join" : [":", ["arn", "aws", "sns", {
+                  "Ref" : "WatchdogRegion"
+                }, {
+                  "Ref" : "AWS::AccountId"
+                }, "rackspace-support-standard"]]
+          }
+        ],
         "MetricName" : "Errors",
         "Namespace" : "AWS/Lambda",
         "ComparisonOperator" : "GreaterThanOrEqualToThreshold",
@@ -148,6 +156,14 @@
       "Properties" : {
         "AlarmDescription" : "Alarm for failed cleanup fanout",
         "AlarmActions" : [{
+            "Fn::Join" : [":", ["arn", "aws", "sns", {
+                  "Ref" : "WatchdogRegion"
+                }, {
+                  "Ref" : "AWS::AccountId"
+                }, "rackspace-support-standard"]]
+          }
+        ],
+        "OKActions" : [{
             "Fn::Join" : [":", ["arn", "aws", "sns", {
                   "Ref" : "WatchdogRegion"
                 }, {
@@ -201,6 +217,14 @@
                 }, "rackspace-support-standard"]]
           }
         ],
+        "OKActions" : [{
+            "Fn::Join" : [":", ["arn", "aws", "sns", {
+                  "Ref" : "WatchdogRegion"
+                }, {
+                  "Ref" : "AWS::AccountId"
+                }, "rackspace-support-standard"]]
+          }
+        ],
         "MetricName" : "Errors",
         "Namespace" : "AWS/Lambda",
         "ComparisonOperator" : "GreaterThanOrEqualToThreshold",
@@ -240,6 +264,14 @@
       "Properties" : {
         "AlarmDescription" : "Alarm for failed snapshot creation",
         "AlarmActions" : [{
+            "Fn::Join" : [":", ["arn", "aws", "sns", {
+                  "Ref" : "WatchdogRegion"
+                }, {
+                  "Ref" : "AWS::AccountId"
+                }, "rackspace-support-standard"]]
+          }
+        ],
+        "OKActions" : [{
             "Fn::Join" : [":", ["arn", "aws", "sns", {
                   "Ref" : "WatchdogRegion"
                 }, {
@@ -293,6 +325,14 @@
                 }, "rackspace-support-standard"]]
           }
         ],
+        "OKActions" : [{
+            "Fn::Join" : [":", ["arn", "aws", "sns", {
+                  "Ref" : "WatchdogRegion"
+                }, {
+                  "Ref" : "AWS::AccountId"
+                }, "rackspace-support-standard"]]
+          }
+        ],
         "MetricName" : "Errors",
         "Namespace" : "AWS/Lambda",
         "ComparisonOperator" : "GreaterThanOrEqualToThreshold",
@@ -332,6 +372,14 @@
       "Properties" : {
         "AlarmDescription" : "Alarm for failed snapshot replication",
         "AlarmActions" : [{
+            "Fn::Join" : [":", ["arn", "aws", "sns", {
+                  "Ref" : "WatchdogRegion"
+                }, {
+                  "Ref" : "AWS::AccountId"
+                }, "rackspace-support-standard"]]
+          }
+        ],
+        "OKActions" : [{
             "Fn::Join" : [":", ["arn", "aws", "sns", {
                   "Ref" : "WatchdogRegion"
                 }, {

--- a/cloudformation.json
+++ b/cloudformation.json
@@ -31,6 +31,26 @@
       "Description" : "CostCenter tag value to apply to resources created by this template.",
       "Type": "String",
       "Default" : ""
+    },
+    "LambdaMemoryFanout" : {
+      "Description" : "Memory (in MB) to use for fanout functions.",
+      "Type": "Number",
+      "Default" : "128"
+    },
+    "LambdaMemorySnapshot" : {
+      "Description" : "Memory (in MB) to use for snapshot function.",
+      "Type": "Number",
+      "Default" : "256"
+    },
+    "LambdaMemoryClean" : {
+      "Description" : "Memory (in MB) to use for clean function.",
+      "Type": "Number",
+      "Default" : "256"
+    },
+    "LambdaMemoryReplication" : {
+      "Description" : "Memory (in MB) to use for replication function.",
+      "Type": "Number",
+      "Default" : "256"
     }
   },
   "Conditions": {
@@ -112,7 +132,7 @@
         },
         "Description" : "snapshot and tags main task",
         "Handler" : "lambdas.lambda_fanout_snapshot",
-        "MemorySize" : 128,
+        "MemorySize" : { "Ref": "LambdaMemoryFanout" },
         "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
         "Runtime" : "python2.7",
         "Timeout" : "300",
@@ -158,7 +178,7 @@
         },
         "Description" : "snapshot and tags main task",
         "Handler" : "lambdas.lambda_fanout_clean",
-        "MemorySize" : 128,
+        "MemorySize" : { "Ref": "LambdaMemoryFanout" },
         "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
         "Runtime" : "python2.7",
         "Timeout" : "300",
@@ -204,7 +224,7 @@
         },
         "Description" : "snapshot and tags main task",
         "Handler" : "lambdas.lambda_fanout_replication",
-        "MemorySize" : 128,
+        "MemorySize" : { "Ref": "LambdaMemoryFanout" },
         "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
         "Runtime" : "python2.7",
         "Timeout" : "300",
@@ -250,7 +270,7 @@
         },
         "Description" : "create tags and snapshots task",
         "Handler" : "lambdas.lambda_snapshot",
-        "MemorySize" : 256,
+        "MemorySize" : { "Ref": "LambdaMemorySnapshot" },
         "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
         "Runtime" : "python2.7",
         "Timeout" : "300",
@@ -296,7 +316,7 @@
         },
         "Description" : "create tags and snapshots task",
         "Handler" : "lambdas.lambda_clean",
-        "MemorySize" : 256,
+        "MemorySize" : { "Ref": "LambdaMemoryClean" },
         "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
         "Runtime" : "python2.7",
         "Timeout" : "300",
@@ -342,7 +362,7 @@
         },
         "Description" : "snapshot replication task",
         "Handler" : "lambdas.lambda_replication",
-        "MemorySize" : 256,
+        "MemorySize" : { "Ref": "LambdaMemoryReplication" },
         "Role" : { "Fn::GetAtt" : ["LambdaExecutionRole", "Arn"] },
         "Runtime" : "python2.7",
         "Timeout" : "300",


### PR DESCRIPTION
- Add parameters to CloudFormation for all of the memory sizes of Lambda jobs. (#58)
- Modify deploy command to preserve all existing parameter values, when they're present. (#58)
- Now that it's supported by Watchman, add OK actions to our alarms. (#55)
- Add more references to the replication feature in ebs-snapper. (#54)