### PR TITLE
Correct invalid json

### DIFF
--- a/cloudformation.json
+++ b/cloudformation.json
@@ -65,7 +65,7 @@
           ]
         }
       ]
-    },
+    }
   },
   "Resources" : {
     "EbsSnapshotConfigurationTable" : {
@@ -458,7 +458,7 @@
                     "events:Describe*",
                     "events:List*",
                     "events:EnableRule",
-                    "events:DisableRule",
+                    "events:DisableRule"
                   ],
                   "Resource" : "*"
                 }, {


### PR DESCRIPTION
When looking at the Lambda page with the AWS console, I noticed that a 500 service error was occurring. Working with AWS support we tracked it down to the invalid json within cloudformation.json. 

After redeploying ebs-snapper with valid json the 500 error goes away. 

A couple of trailing commas which passes the yaml spec have been removed.