### PR TITLE
Use newer CreateSnapshot API call with tags

### DIFF
--- a/ebs_snapper/utils.py
+++ b/ebs_snapper/utils.py
@@ -396,14 +396,14 @@ def snapshot_and_tag(instance_id, ami_id, volume_id, delete_on, region, addition
 
     ec2 = boto3.client('ec2', region_name=region)
 
+    # raise Exception(str(full_tags[:50]))
     snapshot = ec2.create_snapshot(
         VolumeId=volume_id,
-        Description=snapshot_description[0:254]
-    )
-
-    ec2.create_tags(
-        Resources=[snapshot['SnapshotId']],
-        Tags=full_tags[:50]
+        Description=snapshot_description[0:254],
+        TagSpecifications=[{
+            'ResourceType': 'snapshot',
+            'Tags': full_tags[:50]
+        }]
     )
 
     LOG.debug('Finished snapshot in %s of volume %s, valid until %s',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 dicttoxml==1.7.4
 flake8==3.3.0
-moto==1.3.2
+moto==1.3.3
 pylint==1.7.1
 pytest-mock==1.5.0
 pytest==3.0.6

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 dicttoxml==1.7.4
 flake8==3.3.0
-moto==1.0.1
+moto==1.3.2
 pylint==1.7.1
 pytest-mock==1.5.0
 pytest==3.0.6


### PR DESCRIPTION
This uses the newer API call argument that accepts tags, so we don't have to tag separately when creating EBS snapshots.

NOTE: the mock library just added support for this call in https://github.com/spulec/moto/pull/1550, and it's unreleased, so tests will fail until moto is released (something after 1.3.2).
