### PR TITLE
New EC2 tag limits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-boto3==1.4.4
+boto3==1.7.4
 boto==2.47.0
-botocore==1.5.69
+botocore==1.10.4
 crontab==0.21.3
 lambda-uploader==1.1.0
 pytimeparse==1.1.5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -251,7 +251,8 @@ def test_calculate_relevant_tags():
         {'Key': 'BusinessUnit', 'Value': 'Dept2'},  # billing tag override
         {'Key': 'Cluster', 'Value': 'Bank'}  # billing tag that won't override
     ]
-    for i in xrange(0, 6):
+    # 47 because volumes can only have 50 tags too
+    for i in xrange(0, 47):
         volume_tags.append({'Key': "foo-" + str(i), 'Value': "bar-" + str(i + 100)})
 
     # create an instance and record the id
@@ -301,6 +302,10 @@ def test_calculate_relevant_tags():
 
     for k, v in expected_pairs.iteritems():
         assert {'Key': k, 'Value': v} in created_snap['Tags']
+
+    # be sure we don't include the last tag of the 50, it should have been chopped off
+    # because of the DeleteOn tag taking an extra space, and 50 tags + DeleteOn > 50 max tags
+    assert {'Key': 'foo-47', 'Value': 'bar-' + str(47 + 100)} not in created_snap['Tags']
 
 
 @mock_ec2


### PR DESCRIPTION
- New EC2 tag limits allow up to 50 tags, so copy them all now. We still prioritize billing tags, the replication source tag, and the delete on tag.
- Update tests to be sure we chop off tags after 50, but copy them before that.
- Update the boto* dependencies.