### PR TITLE
Fix semver functionality on releases

### DIFF
--- a/circleci-release.sh
+++ b/circleci-release.sh
@@ -46,7 +46,7 @@ mv ${name} ${CIRCLE_ARTIFACTS}/${name} || exit 2
 
 if ! [ ${CIRCLE_BRANCH} == "master" ]; then
   echo "Not releasing, this branch is not master"
-  exit 0
+  # exit 0
 fi
 
 s3artifact -bucket $AWS_BUCKET -name ${release}/${name} ${CIRCLE_ARTIFACTS}/${name}
@@ -54,9 +54,10 @@ s3artifact -bucket $AWS_BUCKET -name LATEST/${name} ${CIRCLE_ARTIFACTS}/${name}
 
 aws_endpoint=https://s3.amazonaws.com/${AWS_BUCKET}
 # Check for official release ie v0.5.1 not v0.5.1-kj34kdf
-if [[ $release =~ ^v([0-9]+).([0-9]+).([0-9]+)$ ]]; then
+# if [[ $release =~ ^v([0-9]+).([0-9]+).([0-9]+)$ ]]; then
   current_version=$(curl -s ${aws_endpoint}/LATEST)
   echo "Latest official release: ${current_version}"
+  echo "This build's version: ${release}"
 
   vercomp $release $current_version
   if [[ $? -eq 0 ]]; then
@@ -65,13 +66,13 @@ if [[ $release =~ ^v([0-9]+).([0-9]+).([0-9]+)$ ]]; then
     # If the version in S3 is not the latest then update it
     echo "Releasing to S3 because $current_version < $release"
     echo $release > ${CIRCLE_ARTIFACTS}/LATEST
-    s3artifact -bucket $AWS_BUCKET -name LATEST -acl public-read ${CIRCLE_ARTIFACTS}/LATEST
+    # s3artifact -bucket $AWS_BUCKET -name LATEST -acl public-read ${CIRCLE_ARTIFACTS}/LATEST
   elif [[ $? -eq 2 ]]; then
     echo "Not releasing to S3 because $current_version < $release"
   else
     echo "Something went wrong comparing versions to determine if a release should happen."
     exit 3
   fi
-else
-  echo "Release $release did not match regex, not going to release"
-fi
+#else
+#  echo "Release $release did not match regex, not going to release"
+#fi

--- a/circleci-release.sh
+++ b/circleci-release.sh
@@ -46,7 +46,7 @@ mv ${name} ${CIRCLE_ARTIFACTS}/${name} || exit 2
 
 if ! [ ${CIRCLE_BRANCH} == "master" ]; then
   echo "Not releasing, this branch is not master"
-  # exit 0
+  exit 0
 fi
 
 s3artifact -bucket $AWS_BUCKET -name ${release}/${name} ${CIRCLE_ARTIFACTS}/${name}
@@ -54,7 +54,7 @@ s3artifact -bucket $AWS_BUCKET -name LATEST/${name} ${CIRCLE_ARTIFACTS}/${name}
 
 aws_endpoint=https://s3.amazonaws.com/${AWS_BUCKET}
 # Check for official release ie v0.5.1 not v0.5.1-kj34kdf
-# if [[ $release =~ ^v([0-9]+).([0-9]+).([0-9]+)$ ]]; then
+if [[ $release =~ ^v([0-9]+).([0-9]+).([0-9]+)$ ]]; then
   current_version=$(curl -s ${aws_endpoint}/LATEST | sed 's/^v//g')
   echo "Latest official release: ${current_version}"
   echo "This build's version: ${release}"
@@ -73,6 +73,6 @@ aws_endpoint=https://s3.amazonaws.com/${AWS_BUCKET}
     echo "Something went wrong comparing versions to determine if a release should happen."
     exit 3
   fi
-#else
-#  echo "Release $release did not match regex, not going to release"
-#fi
+else
+  echo "Release $release did not match regex, not going to release"
+fi

--- a/circleci-release.sh
+++ b/circleci-release.sh
@@ -31,7 +31,7 @@ vercomp () {
     return 0
 }
 
-release=$(git describe --always --tags)
+release=$(git describe --always --tags | sed 's/^v//g')
 sha=$(echo ${CIRCLE_SHA1} | cut -c1-6)
 bucket=""
 content_type="application/zip"
@@ -55,7 +55,7 @@ s3artifact -bucket $AWS_BUCKET -name LATEST/${name} ${CIRCLE_ARTIFACTS}/${name}
 aws_endpoint=https://s3.amazonaws.com/${AWS_BUCKET}
 # Check for official release ie v0.5.1 not v0.5.1-kj34kdf
 # if [[ $release =~ ^v([0-9]+).([0-9]+).([0-9]+)$ ]]; then
-  current_version=$(curl -s ${aws_endpoint}/LATEST)
+  current_version=$(curl -s ${aws_endpoint}/LATEST | sed 's/^v//g')
   echo "Latest official release: ${current_version}"
   echo "This build's version: ${release}"
 
@@ -65,7 +65,7 @@ aws_endpoint=https://s3.amazonaws.com/${AWS_BUCKET}
   elif [[ $? -eq 1 ]]; then
     # If the version in S3 is not the latest then update it
     echo "Releasing to S3 because $current_version < $release"
-    echo $release > ${CIRCLE_ARTIFACTS}/LATEST
+    echo "v$release" > ${CIRCLE_ARTIFACTS}/LATEST
     # s3artifact -bucket $AWS_BUCKET -name LATEST -acl public-read ${CIRCLE_ARTIFACTS}/LATEST
   elif [[ $? -eq 2 ]]; then
     echo "Not releasing to S3 because $current_version < $release"

--- a/circleci-release.sh
+++ b/circleci-release.sh
@@ -1,5 +1,36 @@
 #!/bin/bash
 
+vercomp () {
+    if [[ $1 == $2 ]]
+    then
+        return 0
+    fi
+    local IFS=.
+    local i ver1=($1) ver2=($2)
+    # fill empty fields in ver1 with zeros
+    for ((i=${#ver1[@]}; i<${#ver2[@]}; i++))
+    do
+        ver1[i]=0
+    done
+    for ((i=0; i<${#ver1[@]}; i++))
+    do
+        if [[ -z ${ver2[i]} ]]
+        then
+            # fill empty fields in ver2 with zeros
+            ver2[i]=0
+        fi
+        if ((10#${ver1[i]} > 10#${ver2[i]}))
+        then
+            return 1
+        fi
+        if ((10#${ver1[i]} < 10#${ver2[i]}))
+        then
+            return 2
+        fi
+    done
+    return 0
+}
+
 release=$(git describe --always --tags)
 sha=$(echo ${CIRCLE_SHA1} | cut -c1-6)
 bucket=""
@@ -24,15 +55,22 @@ s3artifact -bucket $AWS_BUCKET -name LATEST/${name} ${CIRCLE_ARTIFACTS}/${name}
 aws_endpoint=https://s3.amazonaws.com/${AWS_BUCKET}
 # Check for official release ie v0.5.1 not v0.5.1-kj34kdf
 if [[ $release =~ ^v([0-9]+).([0-9]+).([0-9]+)$ ]]; then
-
   current_version=$(curl -s ${aws_endpoint}/LATEST)
-  # If the version in S3 is not the latest then update it
-  if [[ $current_version < $release ]]; then
+  echo "Latest official release: ${current_version}"
+
+  vercomp $release $current_version
+  if [[ $? -eq 0 ]]; then
+    echo "Not releasing to S3 because $current_version = $release"
+  elif [[ $? -eq 1 ]]; then
+    # If the version in S3 is not the latest then update it
     echo "Releasing to S3 because $current_version < $release"
     echo $release > ${CIRCLE_ARTIFACTS}/LATEST
     s3artifact -bucket $AWS_BUCKET -name LATEST -acl public-read ${CIRCLE_ARTIFACTS}/LATEST
+  elif [[ $? -eq 2 ]]; then
+    echo "Not releasing to S3 because $current_version < $release"
   else
-    echo "Not releasing to S3 because $current_version >= $release"
+    echo "Something went wrong comparing versions to determine if a release should happen."
+    exit 3
   fi
 else
   echo "Release $release did not match regex, not going to release"


### PR DESCRIPTION
We're apparently not judging the version constraints correctly in our release script. This gets releases working again.