### PR TITLE
Remove 'python' from one of the command lines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           command: |
             curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
             sudo python get-pip.py
-            sudo python pip install virtualenv
+            sudo pip install virtualenv
             virtualenv venv
             source venv/bin/activate
             pip install -U pip


### PR DESCRIPTION
Remove `python` from the pip install line