### PR TITLE
Remove master branch check from release script

### DIFF
--- a/circleci-release.sh
+++ b/circleci-release.sh
@@ -46,11 +46,6 @@ echo "Moving ${name} to CircleCI artifacts directory"
 mkdir -p ${CIRCLE_ARTIFACTS}
 mv ${name} ${CIRCLE_ARTIFACTS}/${name} || exit 2
 
-if ! [ ${CIRCLE_BRANCH} == "master" ]; then
-  echo "Not releasing, this branch is not master"
-  exit 0
-fi
-
 s3artifact -bucket $AWS_BUCKET -name v${release}/${name} ${CIRCLE_ARTIFACTS}/${name}
 s3artifact -bucket $AWS_BUCKET -name LATEST/${name} ${CIRCLE_ARTIFACTS}/${name}
 


### PR DESCRIPTION
Remove CIRCLE_BRANCH check due to it conflicting with the new run on release logic. CIRCLE_BRANCH env var does not exist during that run, causing the script to fail. Removing this should not be an issue since branch filtering is now done via CircleCI workflow.