### PR TITLE
Remove quotes around circle artifacts directory

### DIFF
--- a/circleci-release.sh
+++ b/circleci-release.sh
@@ -36,7 +36,7 @@ sha=$(echo ${CIRCLE_SHA1} | cut -c1-6)
 bucket=""
 content_type="application/zip"
 date=$(date -R)
-CIRCLE_ARTIFACTS="~/cwd/artifacts"
+CIRCLE_ARTIFACTS=~/cwd/artifacts
 
 # create zip file
 name=ebs_snapper.zip


### PR DESCRIPTION
Remove quotes around artifacts directory so that it can expand to the full user path.