### PR TITLE
Replication snapshot cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ target/
 
 # lambda function packages
 *.zip
+.lambda_uploader_temp
+
+# VS Code
+.vscode/

--- a/ebs_snapper/replication.py
+++ b/ebs_snapper/replication.py
@@ -23,6 +23,7 @@
 
 from __future__ import print_function
 from time import sleep
+import sys
 import json
 import logging
 import boto3
@@ -74,6 +75,10 @@ def perform_replication(context, region, installed_region='us-east-1'):
     LOG.debug('Fetched all configured ignored IDs rules from DynamoDB')
 
     # 1. collect snapshots from this region
+    snap_cached_src_regions = []
+    snap_cached_dst_regions = []
+    src_snap_list = []
+    replication_snap_list = []
     relevant_tags = ['replication_src_region', 'replication_dst_region']
     found_snapshots = utils.build_replication_cache(
         context,
@@ -82,6 +87,70 @@ def perform_replication(context, region, installed_region='us-east-1'):
         region,
         installed_region
     )
+    # 1a. build snapshot cache from all source regions
+    #snap_cached_src_regions.append(region)
+    for snapshot_regions in found_snapshots.get('replication_src_region', []):
+        # what region did this come from?
+        tag_pairs = snapshot_regions.get('Tags', [])
+        region_tag_pair = [x for x in tag_pairs
+                           if x.get('Key', None) == 'replication_src_region']
+        region_tag_value = region_tag_pair[0].get('Value')
+        if (region_tag_value not in snap_cached_src_regions):
+            LOG.info('Caching snapshots in source region: ' + region_tag_value)
+            snap_cached_src_regions.append(region_tag_value)
+
+            ec2_source = boto3.client('ec2', region_name=region_tag_value)
+            try:
+                response = ec2_source.describe_snapshots(
+                    Filters=[
+                    {'Name': 'tag:replication_dst_region', 'Values': [region]},
+                    ]
+                )
+	        mysnaps = response['Snapshots']
+            except Exception as err:
+                if 'InvalidSnapshot.NotFound' in str(err):
+		    mysnaps = {'Snapshots', []}
+		else:
+		    raise err
+			
+            for snap in mysnaps:
+                src_snap_list.append(snap['SnapshotId'])
+
+            LOG.info('Caching completed for source region: ' + region_tag_value + ': cache size: ' + str(len(src_snap_list)))
+            sleep(1)
+
+    # 1b. build snapshot cache for all destination regions
+    for snapshot_regions in found_snapshots.get('replication_dst_region', []):
+        # which region is destination
+        tag_pairs = snapshot_regions.get('Tags', [])
+        region_tag_pair = [x for x in tag_pairs
+                           if x.get('Key', None) == 'replication_dst_region']
+        region_tag_value = region_tag_pair[0].get('Value')
+        if (region_tag_value not in snap_cached_dst_regions):
+            LOG.info('Caching snapshots in destination region: ' + region_tag_value)
+            snap_cached_dst_regions.append(region_tag_value)
+
+            ec2_source = boto3.client('ec2', region_name=region_tag_value)
+            try:
+                response = ec2_source.describe_snapshots(
+                    Filters=[
+                    {'Name': 'tag:replication_src_region', 'Values': [region]},
+                    ]
+                )
+                mysnaps = response['Snapshots']
+            except Exception as err:
+                if 'InvalidSnapshot.NotFound' in str(err):
+                    mysnaps = {'Snapshots', []}
+                else:
+                    raise err
+
+            for snap in mysnaps:
+                for tags in snap['Tags']:
+                    if tags["Key"] == 'replication_snapshot_id':
+                        replication_snap_list.append(tags["Value"])
+
+            LOG.info('Caching completed for destination region: ' + region_tag_value + ': cache size: ' + str(len(replication_snap_list)))
+            sleep(1)
 
     # 2. evaluate snapshots that were copied to this region, if source not found, delete
     for snapshot in found_snapshots.get('replication_src_region', []):
@@ -113,26 +182,10 @@ def perform_replication(context, region, installed_region='us-east-1'):
                                if x.get('Key', None) == 'replication_snapshot_id']
         snapshotid_tag_value = snapshotid_tag_pair[0].get('Value')
 
-        ec2_source = boto3.client('ec2', region_name=region_tag_value)
-        try:
-            found_originals = ec2_source.describe_snapshots(
-                SnapshotIds=[snapshotid_tag_value],  # we think the original snapshot id is this
-                Filters=[
-                    # where it gets copied to should be us
-                    {'Name': 'tag:replication_dst_region', 'Values': [region]},
-                ]
-            )
-        except Exception as err:
-            if 'InvalidSnapshot.NotFound' in str(err):
-                found_originals = {'Snapshots': []}
-            else:
-                raise err
-
-        num_found = len(found_originals.get('Snapshots', []))
-        if num_found > 0:
+        if snapshotid_tag_value in src_snap_list:
             LOG.info('Not removing this snapshot ' + snapshot_id + ' from ' + region +
                      ' since snapshot_id ' + snapshotid_tag_value +
-                     ' was already found in ' + region_tag_value)
+                     ' was found in ' + region_tag_value)
             continue
 
         # ax it!
@@ -140,6 +193,7 @@ def perform_replication(context, region, installed_region='us-east-1'):
                  ' since snapshot_id ' + snapshotid_tag_value +
                  ' was not found in ' + region_tag_value)
         utils.delete_snapshot(snapshot_id, region)
+        sleep(2)
 
     # 3. evaluate snapshots that should be copied from this region, if dest not found, copy and tag
     for snapshot in found_snapshots.get('replication_dst_region', []):
@@ -165,19 +219,11 @@ def perform_replication(context, region, installed_region='us-east-1'):
         region_tag_pair = [x for x in tag_pairs if x.get('Key', None) == 'replication_dst_region']
         region_tag_value = region_tag_pair[0].get('Value')
 
-        # does it already exist in the target region?
-        ec2_destination = boto3.client('ec2', region_name=region_tag_value)
-        found_replicas = ec2_destination.describe_snapshots(
-            Filters=[
-                # came from our region originally
-                {'Name': 'tag:replication_src_region', 'Values': [region]},
+	name_tag_pair = [x for x in tag_pairs if x.get('Key', None) == 'Name']
+	name_tag_value = name_tag_pair[0].get('Value')
 
-                # came from our snapshot originally
-                {'Name': 'tag:replication_snapshot_id', 'Values': [snapshot_id]}
-            ]
-        )
-        num_found = len(found_replicas.get('Snapshots', []))
-        if num_found > 0:
+        # does it already exist in the target region?
+        if snapshot_id in replication_snap_list:
             LOG.info('Not creating more snapshots, since snapshot_id ' + snapshot_id +
                      ' was already found in ' + region_tag_value)
             continue
@@ -189,5 +235,6 @@ def perform_replication(context, region, installed_region='us-east-1'):
             context,
             region,
             region_tag_value,
+            name_tag_value,
             snapshot_id,
             snapshot_description)

--- a/ebs_snapper/shell.py
+++ b/ebs_snapper/shell.py
@@ -41,8 +41,8 @@ def main(arv=None):
     if not (sys.version_info[0] == 2 and sys.version_info[1] == 7):
         raise RuntimeError('ebs-snapper requires Python 2.7')
 
-    # allow 15m for the cli, instead of lambda's 5
-    CTX.set_remaining_time_in_millis(60000 * 15)
+    # allow 90m for the cli, instead of lambda's 5
+    CTX.set_remaining_time_in_millis(60000 * 90)
 
     parser = argparse.ArgumentParser(
         version=('version %s' % ebs_snapper.__version__),

--- a/ebs_snapper/utils.py
+++ b/ebs_snapper/utils.py
@@ -759,7 +759,8 @@ def build_replication_cache(context, tags, configurations, region, installed_reg
     return found_snapshots
 
 
-def copy_snapshot_and_tag(context, source_region, dest_region, name_tag, snapshot_id, snapshot_description):
+def copy_snapshot_and_tag(context, source_region, dest_region, name_tag, snapshot_id,
+                          snapshot_description):
     """Copy a snapshot to another region and tag it as such"""
     ec2 = boto3.client('ec2', region_name=dest_region)
     try:
@@ -770,14 +771,13 @@ def copy_snapshot_and_tag(context, source_region, dest_region, name_tag, snapsho
         )
         sleep(1)
         created_snapshot_id = result['SnapshotId']
-        ec2.create_tags(
-            Resources=[created_snapshot_id],
-            Tags=[
-                {'Key': 'replication_src_region', 'Value': source_region},
-                {'Key': 'Name', 'Value': name_tag},
-                {'Key': 'replication_snapshot_id', 'Value': snapshot_id}
-            ]
-        )
+        tags = [
+            {'Key': 'replication_src_region', 'Value': source_region},
+            {'Key': 'replication_snapshot_id', 'Value': snapshot_id}
+        ]
+        if name_tag:
+            tags.append({'Key': 'Name', 'Value': name_tag})
+        ec2.create_tags(Resources=[created_snapshot_id], Tags=tags)
 
         return created_snapshot_id
     except Exception as e:

--- a/ebs_snapper/utils.py
+++ b/ebs_snapper/utils.py
@@ -759,7 +759,7 @@ def build_replication_cache(context, tags, configurations, region, installed_reg
     return found_snapshots
 
 
-def copy_snapshot_and_tag(context, source_region, dest_region, snapshot_id, snapshot_description):
+def copy_snapshot_and_tag(context, source_region, dest_region, name_tag, snapshot_id, snapshot_description):
     """Copy a snapshot to another region and tag it as such"""
     ec2 = boto3.client('ec2', region_name=dest_region)
     try:
@@ -774,6 +774,7 @@ def copy_snapshot_and_tag(context, source_region, dest_region, snapshot_id, snap
             Resources=[created_snapshot_id],
             Tags=[
                 {'Key': 'replication_src_region', 'Value': source_region},
+                {'Key': 'Name', 'Value': name_tag},
                 {'Key': 'replication_snapshot_id', 'Value': snapshot_id}
             ]
         )

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name='ebs_snapper',
     description='Collection of AWS Lambda functions create, manage, and delete EBS snapshots',
     keywords='aws lambda ebs ec2 snapshot backup',
-    version='0.10.6',
+    version='0.10.5',
     author='Rackspace',
     author_email='fps@rackspace.com',
     url='https://github.com/rackerlabs/ebs_snapper',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name='ebs_snapper',
     description='Collection of AWS Lambda functions create, manage, and delete EBS snapshots',
     keywords='aws lambda ebs ec2 snapshot backup',
-    version='0.10.5',
+    version='0.10.6',
     author='Rackspace',
     author_email='fps@rackspace.com',
     url='https://github.com/rackerlabs/ebs_snapper',

--- a/tests/test_replication.py
+++ b/tests/test_replication.py
@@ -95,6 +95,7 @@ def test_perform_replication(mocker):
 
     # create a volume in region_a
     volume = client_a.create_volume(Size=100, AvailabilityZone=region_a + "a")
+    snapshot_name = "Snapshot_Name"
     snapshot_description = "Something from EBS Snapper"
     snapshot = client_a.create_snapshot(
         VolumeId=volume['VolumeId'],
@@ -102,7 +103,10 @@ def test_perform_replication(mocker):
     )
     client_a.create_tags(
         Resources=[snapshot['SnapshotId']],
-        Tags=[{'Key': 'replication_dst_region', 'Value': region_b}]
+        Tags=[
+            {'Key': 'replication_dst_region', 'Value': region_b},
+            {'Key': 'Name', 'Value': snapshot_name},
+        ]
     )
 
     # trigger replication, assert that we copied a snapshot to region_b
@@ -112,6 +116,7 @@ def test_perform_replication(mocker):
         ctx,
         region_a,
         region_b,
+        snapshot_name,
         snapshot['SnapshotId'],
         snapshot_description)
 


### PR DESCRIPTION
Initiated in #95 by @attivio-mroca 

> For regions with many snapshots, the replication function was running into the 15m lambda processing limit simply by iterating through snapshots and calling describe_snapshots for each one.
> Added a snapshot cache to the beginning.
> Also copies the "name" tag when replicating snapshots to another region.

Flagging as WIP for now.  I have the updated code deployed in one of our test environments, and assuming logs and metrics over the weekend look good will proceed with merging the changes.