### PR TITLE
Release v0.10.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,24 @@
 # Changelog
 
+## 0.10.6
+
+- Adds snapshot cache to replication tasks to help improve performance
+- Copies `Name` tag for any replicated snapshots.
+
 ## 0.10.5
+
 - Adds handling for disabled regions (#91)
 
 ## 0.10.4
+
 - Fix issue where minimum snaps was not validated.
 
 ## 0.10.3
+
 - Cut a new release since our semver logic was broken (#81)
 
 ## 0.10.2
+
 - Raise tag limits now that EC2 allows up to 50, be sure we prioritize replication tags as well (#78)
 
 ## 0.10.1

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ We strongly recommend [using virtualenv](http://docs.python-guide.org/en/latest/
 
 Since this package is not currently in PyPi, it will need to be installed locally: git clone the repo (choose a tag, please!) to your workstation then run these commands from inside the repo's main directory:
 ```
-git clone git@github.com:rackerlabs/ebs_snapper.git -b v0.10.5
+git clone git@github.com:rackerlabs/ebs_snapper.git -b v0.10.6
 cd ebs_snapper
-wget -O ebs_snapper.zip s3.amazonaws.com/production-ebs-snapper/v0.10.5/ebs_snapper.zip
+wget -O ebs_snapper.zip s3.amazonaws.com/production-ebs-snapper/v0.10.6/ebs_snapper.zip
 pip install -r requirements.txt
 pip install -e .
 ```
@@ -203,13 +203,13 @@ Specifically for the clean job, a cache is built of much of the needed data to d
 ```
 ebs-snapper -V replication
 INFO:root:Performing snapshot replication in region us-east-1
-INFO:root:Working on copying this snapshot snap-0daf235945e307e7c (if needed): Created from i-05d0486d6c8b1ae49 by EbsSnapper(0.10.5) for ami-c7c546d1 from vol-0d4be5bde49115a56
+INFO:root:Working on copying this snapshot snap-0daf235945e307e7c (if needed): Created from i-05d0486d6c8b1ae49 by EbsSnapper(0.10.6) for ami-c7c546d1 from vol-0d4be5bde49115a56
 INFO:root:Not creating more snapshots, since snapshot_id snap-0daf235945e307e7c was already found in us-west-2
-INFO:root:Working on copying this snapshot snap-08123b99992aba69d (if needed): Created from i-088e9520113fb4e35 by EbsSnapper(0.10.5) for ami-7250d264 from vol-0217da8a108684fa4
+INFO:root:Working on copying this snapshot snap-08123b99992aba69d (if needed): Created from i-088e9520113fb4e35 by EbsSnapper(0.10.6) for ami-7250d264 from vol-0217da8a108684fa4
 INFO:root:Not creating more snapshots, since snapshot_id snap-08123b99992aba69d was already found in us-west-2
-INFO:root:Working on copying this snapshot snap-08bb5aff7b2ccef49 (if needed): Created from i-05b64394cd94260f4 by EbsSnapper(0.10.5) for ami-7250d264 from vol-0349099862e322830
+INFO:root:Working on copying this snapshot snap-08bb5aff7b2ccef49 (if needed): Created from i-05b64394cd94260f4 by EbsSnapper(0.10.6) for ami-7250d264 from vol-0349099862e322830
 INFO:root:Not creating more snapshots, since snapshot_id snap-08bb5aff7b2ccef49 was already found in us-west-2
-INFO:root:Working on copying this snapshot snap-06476a1fdf283c0e0 (if needed): Created from i-05b64394cd94260f4 by EbsSnapper(0.10.5) for ami-7250d264 from vol-029e224bfe6c74001
+INFO:root:Working on copying this snapshot snap-06476a1fdf283c0e0 (if needed): Created from i-05b64394cd94260f4 by EbsSnapper(0.10.6) for ami-7250d264 from vol-029e224bfe6c74001
 INFO:root:Not creating more snapshots, since snapshot_id snap-0e30eba44dc55832e was already found in us-west-2
 WARNING:root:Lambda/Less than 1m remaining in function (59725ms): perform_replication
 INFO:root:Performing snapshot replication in region us-west-1

--- a/ebs_snapper/__init__.py
+++ b/ebs_snapper/__init__.py
@@ -25,7 +25,7 @@ import logging
 import sys
 
 __title__ = 'ebs_snapper'
-__version__ = '0.10.5'
+__version__ = '0.10.6'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright Rackspace US, Inc. 2015-2017'
 __url__ = 'https://github.com/rackerlabs/ebs-snapper-lambda-v2'

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     name='ebs_snapper',
     description='Collection of AWS Lambda functions create, manage, and delete EBS snapshots',
     keywords='aws lambda ebs ec2 snapshot backup',
-    version='0.10.5',
+    version='0.10.6',
     author='Rackspace',
     author_email='fps@rackspace.com',
     url='https://github.com/rackerlabs/ebs_snapper',


### PR DESCRIPTION
- Adds snapshot cache to replication tasks to help improve performance
- Copies `Name` tag for any replicated snapshots.